### PR TITLE
Backward-compatibility of XML file

### DIFF
--- a/hdtv/plugins/fitlist.py
+++ b/hdtv/plugins/fitlist.py
@@ -55,12 +55,10 @@ class FitlistManager(object):
         spec = self.spectra.dict[sid]
         # remember absolute pathname for later use
         fname = os.path.abspath(fname)
-        print(self.list)
         if associate:
             self.list[spec.name] = fname
         else:
             self.list.pop(spec.name, None)
-        print(self.list)
         with hdtv.util.open_compressed(fname, mode='rb') as f:
             self.xml.ReadFitlist(f, sid,
                  calibrate=calibrate, refit=refit,

--- a/test/fitxml/test_oldxml.py
+++ b/test/fitxml/test_oldxml.py
@@ -44,7 +44,8 @@ from hdtv.plugins.fitlist import fitxml
 testspectrum = os.path.join(
     os.path.curdir, "test", "share", "osiris_bg.spc")
 
-test_versions = ['0.1', '1.0', '1.1', '1.3', '1.4']
+test_versions = ['0.1', '1.0', '1.1', '1.3', '1.4', '1.5']
+
 test_XMLs = [
     os.path.join(os.path.curdir, 'test', 'share', 'osiris_bg_v' + ver + '.xml')
     for ver in test_versions]
@@ -61,8 +62,12 @@ def prepare():
 
 @pytest.mark.parametrize("xmlfile", test_XMLs)
 def test_old_xml(xmlfile):
+    # Check whether hdtv recognizes the format of the XML file at all
+    # by invoking the general ReadXML function.
+    # Note that this does not ensure the correct reading of the XML file.
     fitxml.ReadXML(spectra.Get("0").ID, xmlfile, refit=True, interactive=False)
-    fit_interface.ListFits()
+
+
 
 """
 print('Saving fits to file %s' % newXML)


### PR DESCRIPTION
- Introduce new XML file version
- Fix reading of older XML files, which have a different notation for
the background parameters
- For future testing of the correct reading of the XML files, introduced 'interactive' parameters to switch off the interactive mode for testing.